### PR TITLE
Add hooks to set the Sampling Rate from the SCPI RATE command

### DIFF
--- a/source/TS.NET.Engine/DTOs/HardwareRequestDto.cs
+++ b/source/TS.NET.Engine/DTOs/HardwareRequestDto.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace TS.NET.Engine
 {
@@ -6,6 +6,7 @@ namespace TS.NET.Engine
     public record HardwareStartRequest() : HardwareRequestDto;
     public record HardwareStopRequest() : HardwareRequestDto;
     public record HardwareSetRateRequest(ulong rate) : HardwareRequestDto;
+    public record HardwareGetRatesRequest() : HardwareRequestDto;
 
     public abstract record HardwareSetChannelFrontendRequest(int ChannelIndex) : HardwareRequestDto;
     public record HardwareSetEnabledRequest(int ChannelIndex, bool Enabled) : HardwareSetChannelFrontendRequest(ChannelIndex);

--- a/source/TS.NET.Engine/DTOs/HardwareRequestDto.cs
+++ b/source/TS.NET.Engine/DTOs/HardwareRequestDto.cs
@@ -6,7 +6,7 @@ namespace TS.NET.Engine
     public record HardwareStartRequest() : HardwareRequestDto;
     public record HardwareStopRequest() : HardwareRequestDto;
     public record HardwareSetRateRequest(ulong rate) : HardwareRequestDto;
-    public record HardwareGetRatesRequest() : HardwareRequestDto;
+    public record HardwareGetRateRequest() : HardwareRequestDto;
 
     public abstract record HardwareSetChannelFrontendRequest(int ChannelIndex) : HardwareRequestDto;
     public record HardwareSetEnabledRequest(int ChannelIndex, bool Enabled) : HardwareSetChannelFrontendRequest(ChannelIndex);

--- a/source/TS.NET.Engine/DTOs/HardwareRequestDto.cs
+++ b/source/TS.NET.Engine/DTOs/HardwareRequestDto.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 
 namespace TS.NET.Engine
 {
     public abstract record HardwareRequestDto();
     public record HardwareStartRequest() : HardwareRequestDto;
     public record HardwareStopRequest() : HardwareRequestDto;
+    public record HardwareSetRateRequest(ulong rate) : HardwareRequestDto;
 
     public abstract record HardwareSetChannelFrontendRequest(int ChannelIndex) : HardwareRequestDto;
     public record HardwareSetEnabledRequest(int ChannelIndex, bool Enabled) : HardwareSetChannelFrontendRequest(ChannelIndex);

--- a/source/TS.NET.Engine/DTOs/HardwareResponseDto.cs
+++ b/source/TS.NET.Engine/DTOs/HardwareResponseDto.cs
@@ -3,5 +3,5 @@
 namespace TS.NET.Engine
 {
     public record HardwareResponseDto();
-    public record HardwareGetRatesResponse(ulong SampleRateHz) : HardwareResponseDto;
+    public record HardwareGetRateResponse(ulong SampleRateHz) : HardwareResponseDto;
 }

--- a/source/TS.NET.Engine/DTOs/HardwareResponseDto.cs
+++ b/source/TS.NET.Engine/DTOs/HardwareResponseDto.cs
@@ -3,5 +3,5 @@
 namespace TS.NET.Engine
 {
     public record HardwareResponseDto();
-    public record HardwareGetRatesResponse(ulong SampleTimeFs) : HardwareResponseDto;
+    public record HardwareGetRatesResponse(ulong SampleRateHz) : HardwareResponseDto;
 }

--- a/source/TS.NET.Engine/DTOs/HardwareResponseDto.cs
+++ b/source/TS.NET.Engine/DTOs/HardwareResponseDto.cs
@@ -2,5 +2,6 @@
 
 namespace TS.NET.Engine
 {
-    public record HardwareResponseDto(HardwareRequestDto Request);
+    public record HardwareResponseDto();
+    public record HardwareGetRatesResponse(ulong SampleTimeFs) : HardwareResponseDto;
 }

--- a/source/TS.NET.Engine/Program.cs
+++ b/source/TS.NET.Engine/Program.cs
@@ -131,7 +131,7 @@ class Program
                     ThunderscopeHardwareConfig initialHardwareConfiguration = new();
                     initialHardwareConfiguration.AdcChannelMode = AdcChannelMode.Quad;
                     initialHardwareConfiguration.EnabledChannels = 0x0F;
-                    initialHardwareConfiguration.SampleTimeFs = 1000000;
+                    initialHardwareConfiguration.SampleRateHz = 1000000000;
                     initialHardwareConfiguration.Frontend[0] = ThunderscopeChannelFrontend.Default();
                     initialHardwareConfiguration.Frontend[1] = ThunderscopeChannelFrontend.Default();
                     initialHardwareConfiguration.Frontend[2] = ThunderscopeChannelFrontend.Default();

--- a/source/TS.NET.Engine/Program.cs
+++ b/source/TS.NET.Engine/Program.cs
@@ -131,6 +131,7 @@ class Program
                     ThunderscopeHardwareConfig initialHardwareConfiguration = new();
                     initialHardwareConfiguration.AdcChannelMode = AdcChannelMode.Quad;
                     initialHardwareConfiguration.EnabledChannels = 0x0F;
+                    initialHardwareConfiguration.SampleTimeFs = 1000000;
                     initialHardwareConfiguration.Frontend[0] = ThunderscopeChannelFrontend.Default();
                     initialHardwareConfiguration.Frontend[1] = ThunderscopeChannelFrontend.Default();
                     initialHardwareConfiguration.Frontend[2] = ThunderscopeChannelFrontend.Default();

--- a/source/TS.NET.Engine/Servers/DataServer.cs
+++ b/source/TS.NET.Engine/Servers/DataServer.cs
@@ -84,13 +84,7 @@ namespace TS.NET.Engine
                     var data = bridge.AcquiredDataRegionU8;
 
                     // Remember AdcChannelMode reflects the hardware reality - user may only have 3 channels enabled but hardware has to capture 4.
-                    ulong femtosecondsPerSample = configuration.AdcChannelMode switch
-                    {
-                        AdcChannelMode.Single => 1000000000000000/(configuration.SampleRateHz),         // 1 GSPS
-                        AdcChannelMode.Dual => 1000000000000000/(configuration.SampleRateHz / 2),     // 500 MSPS
-                        AdcChannelMode.Quad => 1000000000000000/(configuration.SampleRateHz / 4),    // 250 MSPS
-                        _ => throw new NotImplementedException(),
-                    };
+                    ulong femtosecondsPerSample = 1000000000000000/configuration.SampleRateHz;
 
                     WaveformHeader header = new()
                     {

--- a/source/TS.NET.Engine/Servers/DataServer.cs
+++ b/source/TS.NET.Engine/Servers/DataServer.cs
@@ -86,9 +86,9 @@ namespace TS.NET.Engine
                     // Remember AdcChannelMode reflects the hardware reality - user may only have 3 channels enabled but hardware has to capture 4.
                     ulong femtosecondsPerSample = configuration.AdcChannelMode switch
                     {
-                        AdcChannelMode.Single => configuration.SampleTimeFs,         // 1 GSPS
-                        AdcChannelMode.Dual => configuration.SampleTimeFs * 2,     // 500 MSPS
-                        AdcChannelMode.Quad => configuration.SampleTimeFs * 4,    // 250 MSPS
+                        AdcChannelMode.Single => 1000000000000000/(configuration.SampleRateHz),         // 1 GSPS
+                        AdcChannelMode.Dual => 1000000000000000/(configuration.SampleRateHz / 2),     // 500 MSPS
+                        AdcChannelMode.Quad => 1000000000000000/(configuration.SampleRateHz / 4),    // 250 MSPS
                         _ => throw new NotImplementedException(),
                     };
 

--- a/source/TS.NET.Engine/Servers/DataServer.cs
+++ b/source/TS.NET.Engine/Servers/DataServer.cs
@@ -86,9 +86,9 @@ namespace TS.NET.Engine
                     // Remember AdcChannelMode reflects the hardware reality - user may only have 3 channels enabled but hardware has to capture 4.
                     ulong femtosecondsPerSample = configuration.AdcChannelMode switch
                     {
-                        AdcChannelMode.Single => 1000000,         // 1 GSPS
-                        AdcChannelMode.Dual => 1000000 * 2,     // 500 MSPS
-                        AdcChannelMode.Quad => 1000000 * 4,    // 250 MSPS
+                        AdcChannelMode.Single => configuration.SampleTimeFs,         // 1 GSPS
+                        AdcChannelMode.Dual => configuration.SampleTimeFs * 2,     // 500 MSPS
+                        AdcChannelMode.Quad => configuration.SampleTimeFs * 4,    // 250 MSPS
                         _ => throw new NotImplementedException(),
                     };
 

--- a/source/TS.NET.Engine/Servers/ScpiServer.cs
+++ b/source/TS.NET.Engine/Servers/ScpiServer.cs
@@ -416,7 +416,7 @@ namespace TS.NET.Engine
                                 switch (response)
                                 {
                                     case HardwareGetRatesResponse hardwareGetRatesResponse:
-                                        return $"{hardwareGetRatesResponse.SampleTimeFs:F0},\n";
+                                        return $"{hardwareGetRatesResponse.SampleRateHz:F0},\n";
                                     default:
                                         logger.LogWarning($"Did not get correct response to {nameof(HardwareGetRatesResponse)}");
                                         return "";

--- a/source/TS.NET.Engine/Servers/ScpiServer.cs
+++ b/source/TS.NET.Engine/Servers/ScpiServer.cs
@@ -410,23 +410,14 @@ namespace TS.NET.Engine
                             logger.LogDebug("Reply to *IDN? query");
                             return "ThunderScope,(Bridge),NOSERIAL,NOVERSION\n";
                         case "RATES":
-                            hardwareRequestChannel.Write(new HardwareGetRatesRequest());
-                            if (hardwareResponseChannel.TryRead(out var response, 100))
-                            {
-                                switch (response)
-                                {
-                                    case HardwareGetRatesResponse hardwareGetRatesResponse:
-                                        return $"{hardwareGetRatesResponse.SampleRateHz:F0},\n";
-                                    default:
-                                        logger.LogWarning($"Did not get correct response to {nameof(HardwareGetRatesResponse)}");
-                                        return "";
-                                }
-                            }
-                            else
-                            {
-                                logger.LogWarning($"Did not get any response to {nameof(ProcessingGetRateRequestDto)}");
-                                return "";
-                            }
+                            List<string> rates = new();
+                            rates.Add("1000000000");
+                            rates.Add("750000000");
+                            rates.Add("500000000");
+                            rates.Add("250000000");
+                            rates.Add("125000000");
+                            return $"{string.Join(",", rates)},\n";
+
                         case "DEPTHS":
                             List<string> depths = new();
                             int baseCount = 1000;

--- a/source/TS.NET.Engine/Servers/ScpiServer.cs
+++ b/source/TS.NET.Engine/Servers/ScpiServer.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using NetCoreServer;
 using System.Net;
 using System.Net.Sockets;
@@ -155,9 +155,9 @@ namespace TS.NET.Engine
                                 case "RATE":
                                     if (argument != null)
                                     {
-                                        long rate = Convert.ToInt64(argument);
-                                        processingRequestChannel.Write(new ProcessingSetRateDto(rate));
-                                        logger.LogDebug($"{nameof(ProcessingSetRateDto)} sent with argument: {rate}");
+                                        ulong rate = Convert.ToUInt64(argument);
+                                        hardwareRequestChannel.Write(new HardwareSetRateRequest(rate));
+                                        logger.LogDebug($"{nameof(HardwareSetRateRequest)} sent with argument: {rate}");
                                     }
                                     return null;
                             }

--- a/source/TS.NET.Engine/Servers/ScpiServer.cs
+++ b/source/TS.NET.Engine/Servers/ScpiServer.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using NetCoreServer;
 using System.Net;
 using System.Net.Sockets;
@@ -410,15 +410,15 @@ namespace TS.NET.Engine
                             logger.LogDebug("Reply to *IDN? query");
                             return "ThunderScope,(Bridge),NOSERIAL,NOVERSION\n";
                         case "RATES":
-                            processingRequestChannel.Write(new ProcessingGetRateRequestDto());
-                            if (processingResponseChannel.TryRead(out var response, 100))
+                            hardwareRequestChannel.Write(new HardwareGetRatesRequest());
+                            if (hardwareResponseChannel.TryRead(out var response, 100))
                             {
                                 switch (response)
                                 {
-                                    case ProcessingGetRateResponseDto hardwareGetRateResponse:
-                                        return $"{1000000000000000 / hardwareGetRateResponse.SampleRate:F0},\n";
+                                    case HardwareGetRatesResponse hardwareGetRatesResponse:
+                                        return $"{hardwareGetRatesResponse.SampleTimeFs:F0},\n";
                                     default:
-                                        logger.LogWarning($"Did not get correct response to {nameof(ProcessingGetRateRequestDto)}");
+                                        logger.LogWarning($"Did not get correct response to {nameof(HardwareGetRatesResponse)}");
                                         return "";
                                 }
                             }

--- a/source/TS.NET.Engine/Tasks/HardwareThread.cs
+++ b/source/TS.NET.Engine/Tasks/HardwareThread.cs
@@ -150,13 +150,13 @@ namespace TS.NET.Engine
                                         switch (config.AdcChannelMode)
                                         {
                                             case AdcChannelMode.Single:
-                                                hardwareResponseChannel.Write(new HardwareGetRatesResponse(config.SampleTimeFs));
+                                                hardwareResponseChannel.Write(new HardwareGetRatesResponse(config.SampleRateHz));
                                                 break;
                                             case AdcChannelMode.Dual:
-                                                hardwareResponseChannel.Write(new HardwareGetRatesResponse(config.SampleTimeFs*2));
+                                                hardwareResponseChannel.Write(new HardwareGetRatesResponse(config.SampleRateHz/2));
                                                 break;
                                             case AdcChannelMode.Quad:
-                                                hardwareResponseChannel.Write(new HardwareGetRatesResponse(config.SampleTimeFs*4));
+                                                hardwareResponseChannel.Write(new HardwareGetRatesResponse(config.SampleRateHz/4));
                                                 break;
                                         }
                                         logger.LogDebug($"{nameof(HardwareGetRatesResponse)}");

--- a/source/TS.NET.Engine/Tasks/HardwareThread.cs
+++ b/source/TS.NET.Engine/Tasks/HardwareThread.cs
@@ -143,23 +143,12 @@ namespace TS.NET.Engine
                                         logger.LogDebug($"{nameof(hardwareSetRateRequest)} (rate: {hardwareSetRateRequest.rate})");
                                         break;
                                     }
-                                case HardwareGetRatesRequest hardwareGetRatesRequest:
+                                case HardwareGetRateRequest hardwareGetRateRequest:
                                     {
-                                        logger.LogDebug($"{nameof(HardwareGetRatesRequest)}");
+                                        logger.LogDebug($"{nameof(HardwareGetRateRequest)}");
                                         var config = thunderscope.GetConfiguration();
-                                        switch (config.AdcChannelMode)
-                                        {
-                                            case AdcChannelMode.Single:
-                                                hardwareResponseChannel.Write(new HardwareGetRatesResponse(config.SampleRateHz));
-                                                break;
-                                            case AdcChannelMode.Dual:
-                                                hardwareResponseChannel.Write(new HardwareGetRatesResponse(config.SampleRateHz/2));
-                                                break;
-                                            case AdcChannelMode.Quad:
-                                                hardwareResponseChannel.Write(new HardwareGetRatesResponse(config.SampleRateHz/4));
-                                                break;
-                                        }
-                                        logger.LogDebug($"{nameof(HardwareGetRatesResponse)}");
+                                        hardwareResponseChannel.Write(new HardwareGetRateResponse(config.SampleRateHz));
+                                        logger.LogDebug($"{nameof(HardwareGetRateResponse)}");
                                         break;
                                     }
                                 case HardwareSetChannelCalibrationRequest hardwareSetChannelCalibrationDto:

--- a/source/TS.NET.Engine/Tasks/HardwareThread.cs
+++ b/source/TS.NET.Engine/Tasks/HardwareThread.cs
@@ -139,11 +139,8 @@ namespace TS.NET.Engine
                                     }
                                 case HardwareSetRateRequest hardwareSetRateRequest:
                                     {
-                                        if(thunderscope is Driver.LiteX.Thunderscope liteXThunderscope)
-                                        {
-                                            liteXThunderscope.SetRate(hardwareSetRateRequest.rate);
-                                            logger.LogDebug($"{nameof(hardwareSetRateRequest)} (rate: {hardwareSetRateRequest.rate})");
-                                        }
+                                        thunderscope.SetRate(hardwareSetRateRequest.rate);
+                                        logger.LogDebug($"{nameof(hardwareSetRateRequest)} (rate: {hardwareSetRateRequest.rate})");
                                         break;
                                     }
                                 case HardwareGetRatesRequest hardwareGetRatesRequest:

--- a/source/TS.NET.Engine/Tasks/HardwareThread.cs
+++ b/source/TS.NET.Engine/Tasks/HardwareThread.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using System.Diagnostics;
 
 namespace TS.NET.Engine
@@ -144,6 +144,25 @@ namespace TS.NET.Engine
                                             liteXThunderscope.SetRate(hardwareSetRateRequest.rate);
                                             logger.LogDebug($"{nameof(hardwareSetRateRequest)} (rate: {hardwareSetRateRequest.rate})");
                                         }
+                                        break;
+                                    }
+                                case HardwareGetRatesRequest hardwareGetRatesRequest:
+                                    {
+                                        logger.LogDebug($"{nameof(HardwareGetRatesRequest)}");
+                                        var config = thunderscope.GetConfiguration();
+                                        switch (config.AdcChannelMode)
+                                        {
+                                            case AdcChannelMode.Single:
+                                                hardwareResponseChannel.Write(new HardwareGetRatesResponse(config.SampleTimeFs));
+                                                break;
+                                            case AdcChannelMode.Dual:
+                                                hardwareResponseChannel.Write(new HardwareGetRatesResponse(config.SampleTimeFs*2));
+                                                break;
+                                            case AdcChannelMode.Quad:
+                                                hardwareResponseChannel.Write(new HardwareGetRatesResponse(config.SampleTimeFs*4));
+                                                break;
+                                        }
+                                        logger.LogDebug($"{nameof(HardwareGetRatesResponse)}");
                                         break;
                                     }
                                 case HardwareSetChannelCalibrationRequest hardwareSetChannelCalibrationDto:

--- a/source/TS.NET.Engine/Tasks/HardwareThread.cs
+++ b/source/TS.NET.Engine/Tasks/HardwareThread.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using System.Diagnostics;
 
 namespace TS.NET.Engine
@@ -135,6 +135,15 @@ namespace TS.NET.Engine
                                                 break;
                                         }
                                         thunderscope.SetChannelFrontend(channelIndex, channelFrontend);
+                                        break;
+                                    }
+                                case HardwareSetRateRequest hardwareSetRateRequest:
+                                    {
+                                        if(thunderscope is Driver.LiteX.Thunderscope liteXThunderscope)
+                                        {
+                                            liteXThunderscope.SetRate(hardwareSetRateRequest.rate);
+                                            logger.LogDebug($"{nameof(hardwareSetRateRequest)} (rate: {hardwareSetRateRequest.rate})");
+                                        }
                                         break;
                                     }
                                 case HardwareSetChannelCalibrationRequest hardwareSetChannelCalibrationDto:

--- a/source/TS.NET/Drivers/LiteX/Thunderscope.cs
+++ b/source/TS.NET/Drivers/LiteX/Thunderscope.cs
@@ -179,7 +179,7 @@ namespace TS.NET.Driver.LiteX
                                     AdcChannelMode.Quad;
 
             GetStatus();
-            config.SampleTimeFs = 1000000000000000/(ulong)tsHealth.AdcSampleRate;
+            config.SampleRateHz = tsHealth.AdcSampleRate;
 
             return config;
         }
@@ -217,18 +217,15 @@ namespace TS.NET.Driver.LiteX
             return tsHealth;
         }
 
-        public void SetRate(ulong sampleTimeFs)
+        public void SetRate(ulong sampleRateHz)
         {
             if(!open)
                 throw new Exception("Thunderscope not open");
 
-            //Convert femtoseconds to samples/sec
-            ulong rate = 1000000000000000/sampleTimeFs;
-
-            var retVal = Interop.SetSampleMode(tsHandle, (uint)rate, tsHealth.AdcSampleResolution);
+            var retVal = Interop.SetSampleMode(tsHandle, (uint)sampleRateHz, tsHealth.AdcSampleResolution);
 
             if ( retVal != 0)
-                throw new Exception($"Thunderscope failed to set sample rate ({rate})");
+                throw new Exception($"Thunderscope failed to set sample rate ({sampleRateHz})");
         }
 
         public void SetChannelFrontend(int channelIndex, ThunderscopeChannelFrontend channel)

--- a/source/TS.NET/Drivers/LiteX/Thunderscope.cs
+++ b/source/TS.NET/Drivers/LiteX/Thunderscope.cs
@@ -224,8 +224,10 @@ namespace TS.NET.Driver.LiteX
 
             var retVal = Interop.SetSampleMode(tsHandle, (uint)sampleRateHz, tsHealth.AdcSampleResolution);
 
-            if ( retVal != 0)
-                throw new Exception($"Thunderscope failed to set sample rate ({sampleRateHz})");
+            if ( retVal == -2) //Invalid Parameter
+                logger.LogTrace($"Thunderscope failed to set sample rate ({sampleRateHz}): INVALID_PARAMETER");
+            else if (retVal < 0)
+                throw new Exception($"Thunderscope had an errors trying to set sample rate {sampleRateHz} ({retVal})");
         }
 
         public void SetChannelFrontend(int channelIndex, ThunderscopeChannelFrontend channel)

--- a/source/TS.NET/Drivers/LiteX/Thunderscope.cs
+++ b/source/TS.NET/Drivers/LiteX/Thunderscope.cs
@@ -8,6 +8,7 @@ namespace TS.NET.Driver.LiteX
         private bool open = false;
         private nint tsHandle;
         private double[] channel_volt_scale;
+        private ThunderscopeLiteXStatus tsHealth;
 
         private ThunderscopeChannelCalibration[] tsCalibration;
 
@@ -16,6 +17,7 @@ namespace TS.NET.Driver.LiteX
             logger = loggerFactory.CreateLogger("Drivers.LiteX");
             channel_volt_scale = new double[4];
             tsCalibration = new ThunderscopeChannelCalibration[4];
+            tsHealth = new ThunderscopeLiteXStatus();
         }
 
         ~Thunderscope()
@@ -41,6 +43,8 @@ namespace TS.NET.Driver.LiteX
             {
                 SetChannelCalibration(chan, calibration[chan]);
             }
+
+            GetStatus();
         }
 
         public void Close()
@@ -174,6 +178,9 @@ namespace TS.NET.Driver.LiteX
                                     (channelCount == 2) ? AdcChannelMode.Dual :
                                     AdcChannelMode.Quad;
 
+            GetStatus();
+            config.SampleTimeFs = 1000000000000000/(ulong)tsHealth.AdcSampleRate;
+
             return config;
         }
 
@@ -194,7 +201,6 @@ namespace TS.NET.Driver.LiteX
             if (!open)
                 throw new Exception("Thunderscope not open");
 
-            var tsHealth = new ThunderscopeLiteXStatus();
             var litexState = new Interop.tsScopeState_t();
             if (Interop.GetStatus(tsHandle, out litexState) != 0)
                 throw new Exception("");
@@ -209,6 +215,20 @@ namespace TS.NET.Driver.LiteX
             tsHealth.VccBram = litexState.vcc_bram / 1000.0;
 
             return tsHealth;
+        }
+
+        public void SetRate(ulong rate_fs)
+        {
+            if(!open)
+                throw new Exception("Thunderscope not open");
+
+            //Convert femtoseconds to samples/sec
+            ulong rate = 1000000000000000/rate_fs;
+
+            var retVal = Interop.SetSampleMode(tsHandle, (uint)rate, tsHealth.AdcSampleResolution);
+
+            if ( retVal != 0)
+                throw new Exception($"Thunderscope failed to set sample rate ({rate})");
         }
 
         public void SetChannelFrontend(int channelIndex, ThunderscopeChannelFrontend channel)

--- a/source/TS.NET/Drivers/LiteX/Thunderscope.cs
+++ b/source/TS.NET/Drivers/LiteX/Thunderscope.cs
@@ -217,13 +217,13 @@ namespace TS.NET.Driver.LiteX
             return tsHealth;
         }
 
-        public void SetRate(ulong rate_fs)
+        public void SetRate(ulong sampleTimeFs)
         {
             if(!open)
                 throw new Exception("Thunderscope not open");
 
             //Convert femtoseconds to samples/sec
-            ulong rate = 1000000000000000/rate_fs;
+            ulong rate = 1000000000000000/sampleTimeFs;
 
             var retVal = Interop.SetSampleMode(tsHandle, (uint)rate, tsHealth.AdcSampleResolution);
 

--- a/source/TS.NET/Drivers/Simulator/Thunderscope.cs
+++ b/source/TS.NET/Drivers/Simulator/Thunderscope.cs
@@ -71,5 +71,8 @@
         {
             throw new NotImplementedException();
         }
+        public void SetRate(ulong sampleTimeFs)
+        {
+        }
     }
 }

--- a/source/TS.NET/Drivers/Simulator/Thunderscope.cs
+++ b/source/TS.NET/Drivers/Simulator/Thunderscope.cs
@@ -18,6 +18,7 @@
             config.Frontend[1].ActualVoltFullScale = 1;
             config.Frontend[2].ActualVoltFullScale = 1;
             config.Frontend[3].ActualVoltFullScale = 1;
+            config.SampleTimeFs = 1000000;
             return config;
         }
 

--- a/source/TS.NET/Drivers/Simulator/Thunderscope.cs
+++ b/source/TS.NET/Drivers/Simulator/Thunderscope.cs
@@ -18,7 +18,7 @@
             config.Frontend[1].ActualVoltFullScale = 1;
             config.Frontend[2].ActualVoltFullScale = 1;
             config.Frontend[3].ActualVoltFullScale = 1;
-            config.SampleTimeFs = 1000000;
+            config.SampleRateHz = 1000000000;
             return config;
         }
 
@@ -71,7 +71,7 @@
         {
             throw new NotImplementedException();
         }
-        public void SetRate(ulong sampleTimeFs)
+        public void SetRate(ulong sampleRateHz)
         {
         }
     }

--- a/source/TS.NET/Drivers/XMDA/Thunderscope.cs
+++ b/source/TS.NET/Drivers/XMDA/Thunderscope.cs
@@ -170,6 +170,9 @@ namespace TS.NET.Driver.XMDA
         {
             return configuration;
         }
+        public void SetRate(ulong sampleTimeFs)
+        {
+        }
 
         public void ResetBuffer()
         {

--- a/source/TS.NET/Drivers/XMDA/Thunderscope.cs
+++ b/source/TS.NET/Drivers/XMDA/Thunderscope.cs
@@ -170,7 +170,7 @@ namespace TS.NET.Driver.XMDA
         {
             return configuration;
         }
-        public void SetRate(ulong sampleTimeFs)
+        public void SetRate(ulong sampleRateHz)
         {
         }
 

--- a/source/TS.NET/IThunderscope.cs
+++ b/source/TS.NET/IThunderscope.cs
@@ -11,6 +11,6 @@
         void SetChannelCalibration(int channelIndex, ThunderscopeChannelCalibration channelCalibration);
         void Read(ThunderscopeMemory data, CancellationToken cancellationToken);
         ThunderscopeHardwareConfig GetConfiguration();
-        void SetRate(ulong sampleTimeFs);
+        void SetRate(ulong sampleRateHz);
     }
 }

--- a/source/TS.NET/IThunderscope.cs
+++ b/source/TS.NET/IThunderscope.cs
@@ -11,5 +11,6 @@
         void SetChannelCalibration(int channelIndex, ThunderscopeChannelCalibration channelCalibration);
         void Read(ThunderscopeMemory data, CancellationToken cancellationToken);
         ThunderscopeHardwareConfig GetConfiguration();
+        void SetRate(ulong sampleTimeFs);
     }
 }

--- a/source/TS.NET/Memory/Structs/ThunderscopeHardwareConfig.cs
+++ b/source/TS.NET/Memory/Structs/ThunderscopeHardwareConfig.cs
@@ -8,6 +8,7 @@ namespace TS.NET
         // If the contents of this struct changes, consider incrementing the BuildVersion on ThunderscopeBridgeHeader
 
         public AdcChannelMode AdcChannelMode;           // The number of channels enabled on ADC. ADC has input mux, e.g. Channel1.Enabled and Channel4.Enabled could have AdcChannels of Two. Useful for UI to know this, in order to clamp maximum sample rate.
+        public ulong SampleTimeFs;                      // Time between samples, femtoseconds
         public byte EnabledChannels;                    // LSB = Ch0, LSB+1 = Ch1, etc
 
         public ThunderscopeChannelFrontendArray Frontend;

--- a/source/TS.NET/Memory/Structs/ThunderscopeHardwareConfig.cs
+++ b/source/TS.NET/Memory/Structs/ThunderscopeHardwareConfig.cs
@@ -8,7 +8,7 @@ namespace TS.NET
         // If the contents of this struct changes, consider incrementing the BuildVersion on ThunderscopeBridgeHeader
 
         public AdcChannelMode AdcChannelMode;           // The number of channels enabled on ADC. ADC has input mux, e.g. Channel1.Enabled and Channel4.Enabled could have AdcChannels of Two. Useful for UI to know this, in order to clamp maximum sample rate.
-        public ulong SampleRateHz;                      // Time between samples, femtoseconds
+        public ulong SampleRateHz;                      // Current Sample Rate
         public byte EnabledChannels;                    // LSB = Ch0, LSB+1 = Ch1, etc
 
         public ThunderscopeChannelFrontendArray Frontend;

--- a/source/TS.NET/Memory/Structs/ThunderscopeHardwareConfig.cs
+++ b/source/TS.NET/Memory/Structs/ThunderscopeHardwareConfig.cs
@@ -8,7 +8,7 @@ namespace TS.NET
         // If the contents of this struct changes, consider incrementing the BuildVersion on ThunderscopeBridgeHeader
 
         public AdcChannelMode AdcChannelMode;           // The number of channels enabled on ADC. ADC has input mux, e.g. Channel1.Enabled and Channel4.Enabled could have AdcChannels of Two. Useful for UI to know this, in order to clamp maximum sample rate.
-        public ulong SampleTimeFs;                      // Time between samples, femtoseconds
+        public ulong SampleRateHz;                      // Time between samples, femtoseconds
         public byte EnabledChannels;                    // LSB = Ch0, LSB+1 = Ch1, etc
 
         public ThunderscopeChannelFrontendArray Frontend;


### PR DESCRIPTION
- Add an interface to the Thunderscope driver that allows setting the sample rate.
- Move handling of the RATE SCPI commands to the Hardware thread
- Respond to the RATES command using the current sampling rate

TODO:
- [x] Add limits to acceptable rates (limits in libtslitex)
- [x] Improve error handling for failed rate change
- [x] Generate a list of allowable RATES for current mode
