### PR TITLE
Fix sample rate status for LiteX

### DIFF
--- a/source/TS.NET.Engine/Tasks/ProcessingThread.cs
+++ b/source/TS.NET.Engine/Tasks/ProcessingThread.cs
@@ -305,7 +305,7 @@ namespace TS.NET.Engine
                             //    sampleBuffers[i].Reset();
                             //}
                             captureBuffer.Reset();
-                            logger.LogTrace("Hardware sample rate change ({0})", cachedHardwareConfig.SampleRateHz);
+                            logger.LogTrace("Hardware sample rate change ({0})", inputDataDto.HardwareConfig.SampleRateHz);
                         }
 
                         if (inputDataDto.HardwareConfig.EnabledChannelsCount() != cachedHardwareConfig.EnabledChannelsCount())

--- a/source/TS.NET/Drivers/LiteX/Thunderscope.cs
+++ b/source/TS.NET/Drivers/LiteX/Thunderscope.cs
@@ -178,7 +178,7 @@ namespace TS.NET.Driver.LiteX
                                     AdcChannelMode.Quad;
 
             GetStatus();
-            config.SampleRateHz = tsHealth.AdcSampleRate / (uint)config.AdcChannelMode;
+            config.SampleRateHz = tsHealth.AdcSampleRate;
 
             return config;
         }


### PR DESCRIPTION
libtslitex should report the channel sample rate now.  Remove the divide by ADC Mode.

Fix log message to print new SampleRate instead of old rate